### PR TITLE
Remove old `20250625202556_drop_user_abailabilities_table` migration

### DIFF
--- a/db/migrate/20250625202556_drop_user_abailabilities_table.rb
+++ b/db/migrate/20250625202556_drop_user_abailabilities_table.rb
@@ -1,5 +1,0 @@
-class DropUserAbailabilitiesTable < ActiveRecord::Migration[8.0]
-  def change
-    drop_table :user_abailabilities
-  end
-end


### PR DESCRIPTION
* This migration does not apply for fresh installs, and looks like it was a cleanup migration, so removing it makes the first-run setup better